### PR TITLE
Update VaporCronSchedulable to use an instance method instead of a static one

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ let job = try app.cron.schedule("* * * * *") {
 import Vapor
 import VaporCron
 
-/// Your job should conform to `VaporCronSchedulable`
+/// Your job should conform to `VaporCronSchedulable` or `VaporCronInstanceSchedulable`
 struct ComplexJob: VaporCronSchedulable {
     static var expression: String { "* * * * *" }
 
@@ -59,6 +59,23 @@ struct ComplexJob: VaporCronSchedulable {
     }
 }
 let complexJob = try app.cron.schedule(ComplexJob.self)
+
+struct ComplexInstanceJob: VaporCronInstanceSchedulable {
+    static var expression: String { "* * * * *" }
+
+    private let application: Application
+    
+    init(application: Application) {
+        self.application = application
+    }
+
+    func task() -> EventLoopFuture<Void> {
+        return application.eventLoopGroup.future().always { _ in
+            print("ComplexJob fired")
+        }
+    }
+}
+let complexInstanceJob = try app.cron.schedule(ComplexInstanceJob.self)
 ```
 
 > 💡you also could call `req.cron.schedule(...)``

--- a/Sources/VaporCron/VaporCron.swift
+++ b/Sources/VaporCron/VaporCron.swift
@@ -8,7 +8,13 @@ public struct VaporCron {
     init (application: Application) {
         self.application = application
     }
-    
+
+    @discardableResult
+    public func schedule<T: VaporCronInstanceSchedulable>(_ jobType: T.Type) throws -> NIOCronJob {
+        let job = T(application: application)
+        return try schedule(T.expression) { job.task() }
+    }
+
     @discardableResult
     public func schedule<T: VaporCronSchedulable>(_ job: T.Type) throws -> NIOCronJob {
         return try schedule(job.expression) { job.task(on: self.application) }
@@ -42,9 +48,18 @@ extension Request {
     }
 }
 
+public protocol VaporCronInstanceSchedulable: NIOCronExpressable {
+    associatedtype T
+
+    init(application: Application)
+
+    @discardableResult
+    func task() -> EventLoopFuture<T>
+}
+
 public protocol VaporCronSchedulable: NIOCronExpressable {
     associatedtype T
-    
+
     @discardableResult
     static func task(on application: Application) -> EventLoopFuture<T>
 }

--- a/Tests/VaporCronTests/VaporCronTests.swift
+++ b/Tests/VaporCronTests/VaporCronTests.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import VaporCron
 
 final class VaporCronTests: XCTestCase {
-    static var allTests = []
+    static var allTests: [String] = []
 }


### PR DESCRIPTION
⚠️Warning⚠️  This is a breaking change!

### Rationale 

This PR is a proposal to update the API for `VaporCronSchedulable` to allow for more flexibility. Changing the `task` method to an instance method instead of static allows for an implementation outlined below. This makes it easier to organize code into small functions, adds type safety to member variables, and prevents the below anti-pattern.

```
/// New Way
struct MyCronJob: VaporCronSchedulable {
    static var expression: String { "* * * * *" }

    private let application: Application
    private let service: MyService
    private let databaseHelper: MyDatabaseHelper

    init(application: Application) {
        self.application = application
        self.service = MyService(app: application)
        self.databaseHelper = MyDatabaseHelper(db: application.db)
    }
}

extension MyCronJob {
    
    func task() throws -> EventLoopFuture<Void> {
        service.request()
            .flatMap { helper($0) }
    }

    func helper(response: MyResponse) -> EventLoopFuture<Void> {
        databaseHelper.store(response)
    }
}
```

This prevents an anti-pattern of storing static variables to share between helper functions, which is unsafe in a multithreaded environment:

```
/// Old Way
struct MyCronJob: VaporCronSchedulable {
    static var expression: String { "* * * * *" } 

    static private var service: MyService! // Unsafe unwrap is not ideal
    static private var databaseHelper: MyDatabaseHelper! // If task is called twice, this could get overwritten

    static func task(on application: Application) -> EventLoopFuture<Void> {
        service = MyService(app: application)
        databaseHelper = MyDatabaseHelper(db: application.db)

        return service.request()
            .flatMap { helper($0) }
    }

    static func helper(response: MyResponse) -> EventLoopFuture<Void> {
        databaseHelper.store(response)
    }
}
```

### Workarounds

The current workaround to avoid the above anti-pattern is to pass `Application` in as a parameter to every helper function. This gets tedious for any class of sufficient size.

### Bonus

I've also updated `task()` to be a throwing function, which seems to be supported by the other schedule methods.