### PR TITLE
Fix `AsyncVaporCronInstanceSchedulable` protocol error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,26 @@ let complexInstanceJob = try app.cron.schedule(ComplexInstanceJob.self)
 > 💡you also could call `req.cron.schedule(...)``
 
 > 💡💡Scheduled job may be cancelled just by calling `.cancel()`
+ 
+### Concurrency (swift>=5.5)
+
+use `AsyncVaporCronSchedulable` instead `VaporCronSchedulable`
+
+use `AsyncVaporCronInstanceSchedulable` instead `VaporCronInstanceSchedulable`
+
+```swift
+public struct TestCron: AsyncVaporCronSchedulable {
+    public typealias T = Void
+    
+    public static var expression: String {
+        "*/1 * * * *"
+    }
+    
+    public static func task(on application: Application) async throws -> Void {
+        application.logger.info("\(Self.self) is running...")
+    }
+}
+``` 
 
 ## Where to define
 

--- a/Sources/VaporCron/VaporCron+Concurrency.swift
+++ b/Sources/VaporCron/VaporCron+Concurrency.swift
@@ -23,16 +23,16 @@ extension AsyncVaporCronSchedulable {
 // MARK: VaporCronInstanceSchedulable
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public protocol AsyncVaporCronInstanceSchedulable: VaporCronInstanceSchedulable {
-    func task(on application: Application) async throws -> T
+    func task() async throws -> T
 }
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 extension AsyncVaporCronInstanceSchedulable {
     
-    public func task(on application: Application) -> EventLoopFuture<T> {
+    public func task() -> EventLoopFuture<T> {
         let promise = application.eventLoopGroup.next().makePromise(of: T.self)
         promise.completeWithTask {
-            try await task(on: application)
+            try await task()
         }
         return promise.futureResult
     }

--- a/Sources/VaporCron/VaporCron+Concurrency.swift
+++ b/Sources/VaporCron/VaporCron+Concurrency.swift
@@ -1,0 +1,42 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
+import Vapor
+
+// MARK: VaporCronSchedulable
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+public protocol AsyncVaporCronSchedulable: VaporCronSchedulable {
+    static func task(on application: Application) async throws -> T
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension AsyncVaporCronSchedulable {
+    
+    public static func task(on application: Application) -> EventLoopFuture<T> {
+        let promise = application.eventLoopGroup.next().makePromise(of: T.self)
+        promise.completeWithTask {
+            try await task(on: application)
+        }
+        return promise.futureResult
+    }
+    
+}
+
+// MARK: VaporCronInstanceSchedulable
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+public protocol AsyncVaporCronInstanceSchedulable: VaporCronInstanceSchedulable {
+    func task(on application: Application) async throws -> T
+}
+
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+extension AsyncVaporCronInstanceSchedulable {
+    
+    public func task(on application: Application) -> EventLoopFuture<T> {
+        let promise = application.eventLoopGroup.next().makePromise(of: T.self)
+        promise.completeWithTask {
+            try await task(on: application)
+        }
+        return promise.futureResult
+    }
+    
+}
+#endif
+

--- a/Sources/VaporCron/VaporCron.swift
+++ b/Sources/VaporCron/VaporCron.swift
@@ -50,7 +50,8 @@ extension Request {
 
 public protocol VaporCronInstanceSchedulable: NIOCronExpressable {
     associatedtype T
-
+    
+    var application: Application { get }
     init(application: Application)
 
     @discardableResult


### PR DESCRIPTION
sorry, due to my last negligence, I wrote `func task() -> EventLoopFuture<T>` as `func task(on application: Application) -> EventLoopFuture<T>` 😂, now I fixed it. 

you don't have to worry about this happen again, I have passed the test in my project. 🫣